### PR TITLE
Fix user_id doesn't have a default value error when running seeder

### DIFF
--- a/app/Question.php
+++ b/app/Question.php
@@ -62,7 +62,7 @@ class Question extends Model
 
     public function favorites()
     {
-        return $this->belongsToMany(Question::class, 'favorites'); //, 'user_id', 'question_id');
+        return $this->belongsToMany(User::class, 'favorites'); //, 'user_id', 'question_id');
     }
 
     public function isFavorited()

--- a/database/seeds/FavoritesTableSeeder.php
+++ b/database/seeds/FavoritesTableSeeder.php
@@ -22,6 +22,7 @@ class FavoritesTableSeeder extends Seeder
         foreach (Question::all() as $question) {
             for ($i = 0; $i < rand(1, $numberOfUsers); $i++ ) { 
                 $user = $users[$i];
+                echo $user;
 
                 $question->favorites()->attach($user);
             }


### PR DESCRIPTION
Just replace the model namespace from `Question` to `User` in the `favorites` method.